### PR TITLE
build結果閲覧用のローカルサーバ

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/yoshik/example-abc
+
+go 1.22.5
+
+require github.com/go-chi/chi/v5 v5.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
+github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/local_server.go
+++ b/local_server.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func read(path string) []byte {
+	f, err := os.Open(path)
+	defer f.Close()
+	if err != nil {
+		return ([]byte("{\"error\": \"" + path + " can't read\"}"))
+	} else {
+		byteArray, _ := io.ReadAll(f)
+		return (byteArray)
+	}
+}
+
+func main() {
+	r := chi.NewRouter()
+	folder := "./build"
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		filename := "/index.html"
+		w.Write(read(folder + filename))
+	})
+
+	r.Get("/*", func(w http.ResponseWriter, r *http.Request) {
+		filename := r.URL.Path
+		w.Write(read(folder + filename))
+	})
+	exec.Command("open", "http://localhost:4000").Start()
+	http.ListenAndServe(":4000", r)
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "react-scripts": "^5.0.1"
   },
   "scripts": {
-    "start": "react-scripts start"
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "preview:build": "go run local_server.go"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
#4 

react-scripts buildして結果をローカルから見れるようにする
単純にファイルで開くとクロスオリジン制約に引っかかるためhttp経由のlocalhostから見る
最初は手軽なexpressにしようと思ったが、依存性解決に影響が出たためgoにした