### PR TITLE
APIのステートのリファクタリング

### DIFF
--- a/src/Log.ts
+++ b/src/Log.ts
@@ -1,0 +1,1 @@
+export default console.log;

--- a/src/components/BookAllState.ts
+++ b/src/components/BookAllState.ts
@@ -2,19 +2,19 @@ import { atom } from "recoil";
 import { NetworkState, ExpiredAt, Initialized } from "../models/NetworkState";
 import { ResponseBookAll } from "../apis/client";
 
-interface ListProps {
+interface BookAllProps {
 	networkState: NetworkState;
 	expiredAt: ExpiredAt | null;
 	cache: ResponseBookAll | null;
 }
 
-const initListProps: ListProps = {
+const initBookAllProps: BookAllProps = {
 	networkState: Initialized,
 	expiredAt: null,
 	cache: null,
 };
 
-export const ListState = atom({
-	key: "ListState",
-	default: initListProps,
+export const BookAllState = atom({
+	key: "BookAllState",
+	default: initBookAllProps,
 });

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -1,10 +1,10 @@
 import { useRecoilState } from "recoil";
-import { ListState } from "./ListState";
+import { BookAllState } from "./BookAllState";
 import { ApiBookAll } from "../apis/client";
 import { Loaded } from "../models/NetworkState";
 
 const List = () => {
-	const [state, setState] = useRecoilState(ListState);
+	const [state, setState] = useRecoilState(BookAllState);
 	(async () => {
 		const data = (await ApiBookAll()).data;
 		setState({

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -1,16 +1,13 @@
 import { useRecoilState } from "recoil";
-import { fetchBookAll, BookAllState } from "./BookAllState";
+import { updateBookAll, BookAllState } from "./BookAllState";
 
 const List = () => {
 	const [state, setState] = useRecoilState(BookAllState);
-	(async (state) => {
-		const fetchData = await fetchBookAll(state);
-		if (fetchData) setState(fetchData);
-	})(state);
+	updateBookAll(state, setState);
 	return (
 		<div>
 			<h1>List</h1>
-			<div>{JSON.stringify(state.cache)}</div>
+			<div>{JSON.stringify(state.data)}</div>
 		</div>
 	);
 };

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -1,18 +1,12 @@
 import { useRecoilState } from "recoil";
-import { BookAllState } from "./BookAllState";
-import { ApiBookAll } from "../apis/client";
-import { Loaded } from "../models/NetworkState";
+import { fetchBookAll, BookAllState } from "./BookAllState";
 
 const List = () => {
 	const [state, setState] = useRecoilState(BookAllState);
-	(async () => {
-		const data = (await ApiBookAll()).data;
-		setState({
-			networkState: Loaded,
-			cache: data,
-			expiredAt: new Date(1000 * 60),
-		});
-	})();
+	(async (state) => {
+		const fetchData = await fetchBookAll(state);
+		if (fetchData) setState(fetchData);
+	})(state);
 	return (
 		<div>
 			<h1>List</h1>

--- a/src/models/ExpiredAt.ts
+++ b/src/models/ExpiredAt.ts
@@ -1,0 +1,1 @@
+export type ExpiredAt = Date | null;

--- a/src/models/NetworkState.ts
+++ b/src/models/NetworkState.ts
@@ -1,5 +1,0 @@
-export const Initialized = Symbol();
-export const Loaded = Symbol();
-export const Expired = Symbol();
-export type NetworkState = typeof Initialized | typeof Loaded | typeof Expired;
-export type ExpiredAt = Date;


### PR DESCRIPTION
#11

- ListStateをBookAllStateにリネーム
  - viewの状態でなくapiの状態なので
- NetworkStateを削除して、ExpiredAtのみにする
  - 未ロードかExpiredしたときにインターネットからLoadするが、NetworkStateで明示する必要性が薄そう
  - Expiredを使うタイミングがよく考えるとないので、代わりにerrorが起きたかを明示する